### PR TITLE
Advanced Settings Dropdown & FOUC (flash of unstyled content) corrections

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -84,8 +84,17 @@ td {
 }
 
 #query-text {
+  height: 75%;
   min-width: 80%;
 }
+
+
+.submit-button {
+  height: 75%;
+  white-space:normal;
+  text-align: center; /* this seems to break when page size is too small */
+}
+
 
 #formGroupCenter {
   width: 100%;
@@ -109,24 +118,20 @@ td {
   background-color: #f8f9fa;
 }
 
-.submit-button {
-  width: 80px; /* adjust this to the size you want */
-  margin-right: 1px; /* adds space between buttons */
-}
-
-.nav-button {
-  width: 60px; /* adjust this to the size you want */
-  margin-right: 1px; /* adds space between buttons */
-}
+/*.nav-button {*/
+/*  width: 60px; !* adjust this to the size you want *!*/
+/*  margin-right: 1px; !* adds space between buttons *!*/
+/*}*/
 
 #submitGroup {
   margin-top: 2vh; /* adjust this value as needed */
 }
 
 
-.submit-button {
-  width: 100px; /* adjust this to the size you want */
-  margin-right: 1px; /* adds space between buttons */
+#advancedFeaturesHeader .accordion-button:hover {
+  /*background-color: #007BFF;  !* Change to your preferred color *!*/
+  /*color: white;  !* Change to your preferred color *!*/
+  text-decoration: underline;
 }
 
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -129,11 +129,12 @@ td {
 
 
 #advancedFeaturesHeader .accordion-button:hover {
-  /*background-color: #007BFF;  !* Change to your preferred color *!*/
-  /*color: white;  !* Change to your preferred color *!*/
   text-decoration: underline;
 }
 
+.accordion-button::after {
+  display: none;
+}
 
 .card-title {
   font-size: 0.9em;

--- a/index.html
+++ b/index.html
@@ -3,63 +3,106 @@
 
 <head>
     <title>SemanticFinder - Frontend-only Semantic Search with transformers.js</title>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <link rel="stylesheet" type="text/css" href="css/styles.css">
 </head>
 
 <body>
-    <br />
-    <h1 class="text-center"><span class="highlight-first">SemanticFinder</span></h1>
-    <h2 class="text-center">Frontend-only live semantic search with <a href="https://xenova.github.io/transformers.js/"
-            target="_blank">transformers.js</a>. <a href="https://github.com/do-me/SemanticFinder">GitHub</a></h2>
-    <div class="text-center" style="margin: 0 auto; max-width: 65%;">
-        <p>
-            Semantic search right in your browser! Calculates the embeddings and cosine similarity client-side without
-            server-side inferencing, using a <a
-                href="https://github.com/xenova/transformers.js/issues/36#issuecomment-1476842324">quantized version</a>
-            of <a
-                href="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2">sentence-transformers/all-MiniLM-L6-v2</a>.<br>
-            Demo for <a href="https://geo.rocks/post/semanticfinder-semantic-search-frontend-only/">this blog post</a>,
-            building on two former ones <a
-                href="https://geo.rocks/post/qdrant-transformers-js-semantic-search//">[1]</a>, <a
-                href="https://geo.rocks/post/geospatial-vector-search-qdrant/">[2]</a> about vector search.
-            See other fast (pre-index) examples: <a href="https://geo.rocks/semanticfinder/ipcc">IPCC Report 2023 (85
-                pages)</a>, <a href="https://geo.rocks/semanticfinder/ipcc-summary">IPCC Summary 2023 (35 pages)</a>.
-            <br>For a more refined search, enter a low character count; for a coarser search, enter a high one. Simply
-            copy and paste any text and hit Submit.
-        </p>
-    </div>
+<br/>
+<h1 class="text-center"><span class="highlight-first">SemanticFinder</span></h1>
+<h2 class="text-center">Frontend-only live semantic search with <a href="https://xenova.github.io/transformers.js/"
+                                                                   target="_blank">transformers.js</a>. <a
+        href="https://github.com/do-me/SemanticFinder">GitHub</a></h2>
+<div class="text-center" style="margin: 0 auto; max-width: 65%;">
+    <p>
+        Semantic search right in your browser! Calculates the embeddings and cosine similarity client-side without
+        server-side inferencing, using a <a
+            href="https://github.com/xenova/transformers.js/issues/36#issuecomment-1476842324">quantized version</a>
+        of <a
+            href="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2">sentence-transformers/all-MiniLM-L6-v2</a>.<br>
+        Demo for <a href="https://geo.rocks/post/semanticfinder-semantic-search-frontend-only/">this blog post</a>,
+        building on two former ones <a
+            href="https://geo.rocks/post/qdrant-transformers-js-semantic-search//">[1]</a>, <a
+            href="https://geo.rocks/post/geospatial-vector-search-qdrant/">[2]</a> about vector search.
+        See other fast (pre-index) examples: <a href="https://geo.rocks/semanticfinder/ipcc">IPCC Report 2023 (85
+        pages)</a>, <a href="https://geo.rocks/semanticfinder/ipcc-summary">IPCC Summary 2023 (35 pages)</a>.
+        <br>For a more refined search, enter a low character count; for a coarser search, enter a high one. Simply
+        copy and paste any text and hit Submit.
+    </p>
+</div>
 
-    <div class="container mt-5">
-        <div class="row justify-content-center">
-            <div class="col-sm-9"> <!-- 80% column for text region-->
+<div class="container mt-5">
+    <div class="row justify-content-center">
+        <div class="col-sm-9"> <!-- 80% column for text region-->
 
-                <form class="form-floating" onsubmit="onSubmit(); return false;">
-                    <div class="form-group" id="formGroupCenter">
-                        <div class="form-floating mb-3">
-                            <input type="text" id="query-text" class="form-control" placeholder="Enter query here"
-                                value="food" />
-                            <label for="query-text">query</label>
-                        </div>
-                        <div class="row">
-                            <div class="col-md-6">
-                                <div class="form-floating mb-3">
-                                    <input type="number" id="token-length" class="form-control w-100"
-                                        placeholder="Enter no. of chars" value="50" />
-                                    <label for="token-length"># chars</label>
-                                </div>
-                            </div>
-                            <div class="col-md-6">
-                                <div class="form-floating mb-3">
-                                    <input type="number" id="threshold" class="form-control w-100"
-                                        placeholder="Similarity threshold" value="0.3" step="0.01" />
-                                    <label for="threshold">threshold</label>
-                                </div>
+            <form class="form-floating">
+                <div class="form-group" id="formGroupCenter">
+                    <div class="row no-gutters">
+                        <div class="col-md-10">
+                            <div class="form-floating mb-3">
+                                <input type="text" id="query-text" class="form-control" placeholder="Enter query here"
+                                       value="food"/>
+                                <label for="query-text">query</label>
                             </div>
                         </div>
+                        <div class="col-md-2">
+                            <button onclick="onSubmit(); return false;" id="submit_button"
+                                    class="btn btn-primary submit-button  btn-lg mb-2 form-control" disabled>
+                                Loading...
+                            </button>
+                        </div>
+                        <!--  settings -->
+                        <div class="accordion accordion-flush" id="advancedFeaturesAccordion">
+                            <div class="accordion-item">
+                                <h2 class="accordion-header" id="advancedFeaturesHeader">
+                                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+                                            data-bs-target="#advancedFeaturesContent" aria-expanded="false"
+                                            aria-controls="advancedFeaturesContent">
+                                        Settings »
+                                    </button>
+                                </h2>
+
+                                <div id="advancedFeaturesContent" class="accordion-collapse collapse">
+                                    <div class="accordion-body">
+                                        <div class="container-fluid">
+                                            <div class="row">
+                                                <div class="col-md-4">
+                                                    <div class="form-floating mb-3">
+                                                        <input type="number" id="threshold" class="form-control w-100"
+                                                                value="0.3" step="0.01"/>
+                                                        <label for="threshold">similarity threshold</label>
+                                                    </div>
+                                                </div>
+                                                <div class="col-md-4">
+                                                    <div class="form-floating">
+                                                    <select class="form-select form-control " id="split-type">
+                                                        <option value="Sentence">Sentence</option>
+                                                        <option value="Chars" selected># Chars</option>
+                                                        <option value="Words"># Words</option>
+                                                        <option value="Tokens"># Tokens</option>
+                                                        <option value="Regex">Regex</option>
+                                                    </select>
+                                                    <label for="split-type">split by</label>
+                                                    </div>
+                                                </div>
+                                                <div class="col-md-4">
+                                                    <div class="form-floating mb-3">
+                                                        <input id="split-param" class="form-control w-100"
+                                                        type=number min="1" value="40"/>
+                                                        <label for="split-param"># Chars</label>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!--  text box -->
                         <div class="form-floating">
-                            <textarea id="input-text" class="form-control"
-                                placeholder="Enter notes here">Near a great forest there lived a poor woodcutter and his wife, and his two children; the boy's name was Hansel and the girl's Grethel. They had very little to bite or to sup, and once, when there was great dearth in the land, the man could not even gain the daily bread. As he lay in bed one night thinking of this, and turning and tossing, he sighed heavily, and said to his wife, "What will become of us? we cannot even feed our children; there is nothing left for ourselves."
+                            <textarea id="input-text" class="form-control" placeholder="Enter">Near a great forest there lived a poor woodcutter and his wife, and his two children; the boy's name was Hansel and the girl's Grethel. They had very little to bite or to sup, and once, when there was great dearth in the land, the man could not even gain the daily bread. As he lay in bed one night thinking of this, and turning and tossing, he sighed heavily, and said to his wife, "What will become of us? we cannot even feed our children; there is nothing left for ourselves."
 "I will tell you what, husband," answered the wife; "we will take the children early in the morning into the forest, where it is thickest; we will make them a fire, and we will give each of them a piece of bread, then we will go to our work and leave them alone; they will never find the way home again, and we shall be quit of them."
 "No, wife," said the man, "I cannot do that; I cannot find in my heart to take my children into the forest and to leave them there alone; the wild animals would soon come and devour them." - "O you fool," said she, "then we will all four starve; you had better get the coffins ready," and she left him no peace until he consented. "But I really pity the poor children," said the man.
 The two children had not been able to sleep for hunger, and had heard what their step-mother had said to their father. Grethel wept bitterly, and said to Hansel, "It is all over with us."
@@ -67,41 +110,38 @@ The two children had not been able to sleep for hunger, and had heard what their
 "O father," said Hansel, "lam looking at my little white kitten, who is sitting up on the roof to bid me good-bye." - "You young fool," said the woman, "that is not your kitten, but the sunshine on the chimney-pot." Of course Hansel had not been looking at his kitten, but had been taking every now and then a flint from his pocket and dropping it on the road. When they reached the middle of the forest the father told the children to collect wood to make a fire to keep them, warm; and Hansel and Grethel gathered brushwood enough for a little mountain j and it was set on fire, and when the flame was burning quite high the wife said, "Now lie down by the fire and rest yourselves, you children, and we will go and cut wood; and when we are ready we will come and fetch you."
 So Hansel and Grethel sat by the fire, and at noon they each ate their pieces of bread. They thought their father was in the wood all the time, as they seemed to hear the strokes of the axe: but really it was only a dry branch hanging to a withered tree that the wind moved to and fro. So when they had stayed there a long time their eyelids closed with weariness, and they fell fast asleep.
 When at last they woke it was night, and Grethel began to cry, and said, "How shall we ever get out of this wood? "But Hansel comforted her, saying, "Wait a little while longer, until the moon rises, and then we can easily find the way home." And when the full moon got up Hansel took his little sister by the hand, and followed the way where the flint stones shone like silver, and showed them the road. They walked on the whole night through, and at the break of day they came to their father's house. They knocked at the door, and when the wife opened it and saw that it was Hansel and Grethel she said, "You naughty children, why did you sleep so long in the wood? we thought you were never coming home again!" But the father was glad, for it had gone to his heart to leave them both in the woods alone.
-Not very long after that there was again great scarcity in those parts, and the children heard their mother say at night in bed to their father, "Everything is finished up; we have only half a loaf, and after that the tale comes to an end. The children must be off; we will take them farther into the wood this time, so that they shall not be able to find the way back again; there is no other way to manage." The man felt sad at heart, and he thought, "It would better to share one's last morsel with one's children." But the wife would listen to nothing that he said, but scolded and reproached him. He who says A must say B too, and when a man has given in once he has to do it a second time.</textarea>
-
+Not very long after that there was again great scarcity in those parts, and the children heard their mother say at night in bed to their father, "Everything is finished up; we have only half a loaf, and after that the tale comes to an end. The children must be off; we will take them farther into the wood this time, so that they shall not be able to find the way back again; there is no other way to manage." The man felt sad at heart, and he thought, "It would better to share one's last morsel with one's children." But the wife would listen to nothing that he said, but scolded and reproached him. He who says A must say B too, and when a man has given in once he has to do it a second time.
+                            </textarea>
                         </div>
                     </div>
 
+                    <!--  navigation buttons -->
                     <div class="text-center" id="submitGroup">
-                        <button type="submit" id="submit_button" class="btn btn-primary mb-2 submit-button" disabled>
-                            <div id="loading"></div>
-                            Loading model...
-                        </button>
-                        <button id="prev" class="btn btn-secondary mb-2 nav-button" disabled>
-                            prev
-                        </button>
-                        <button id="next" class="btn btn-secondary mb-2 nav-button" disabled>
-                            next
-                        </button>
-                    </div>
-
-                </form>
-                <div>
-                    <label id="progressBarLabel" for="progressBar">Progress:</label>
-                    <div style="display: flex; align-items: center;">
-                        <p id="progressBarProgress" style="margin: 0 5px 0 0; position: relative; top: 3px;">0%</p>
-                        <progress id="progressBar" value="0" max="100" role="progressbar"></progress>
+                        <button id="prev" class="btn btn-md btn-secondary mb-2 nav-button" disabled>< prev</button>
+                        <button id="next" class="btn btn-md btn-secondary mb-2 nav-button" disabled>next ></button>
                     </div>
                 </div>
-            </div>
+            </form>
 
-            <div class="col-sm-3"> <!-- 20% column -->
-                <div id="results">
-                    <ul id="results-list"> </ul>
+
+            <div>
+                <label id="progressBarLabel" for="progressBar">Progress:</label>
+                <div style="display: flex; align-items: center;">
+                    <p id="progressBarProgress" style="margin: 0 5px 0 0; position: relative; top: 3px;">0%</p>
+                    <progress id="progressBar" value="0" max="100" role="progressbar"></progress>
                 </div>
             </div>
         </div>
+
+        <div class="col-sm-3"> <!-- 20% column -->
+            <div id="results">
+                <ul id="results-list"></ul>
+            </div>
+        </div>
     </div>
+</div>
+<script src="js/index.js" defer></script>
+
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
                             </button>
                         </div>
                         <!--  settings -->
-                        <div class="accordion accordion-flush" id="advancedFeaturesAccordion">
+                        <div class="accordion accordion-flush pb-3" id="advancedFeaturesAccordion">
                             <div class="accordion-item">
                                 <h2 class="accordion-header" id="advancedFeaturesHeader">
                                     <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
                                     <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
                                             data-bs-target="#advancedFeaturesContent" aria-expanded="false"
                                             aria-controls="advancedFeaturesContent">
-                                        Settings »
+                                        Settings ↠
                                     </button>
                                 </h2>
 

--- a/js/index.js
+++ b/js/index.js
@@ -357,6 +357,4 @@ window.onload = async function () {
         prevMarker();
     });
 
-
-
 };

--- a/js/index.js
+++ b/js/index.js
@@ -352,9 +352,8 @@ window.onload = async function () {
         nextMarker();
     });
 
-    window.addEventListener('prev', function (event) {
+    document.getElementById('prev').addEventListener('click', function (event) {
         event.preventDefault();
         prevMarker();
     });
-
 };

--- a/js/semantic.js
+++ b/js/semantic.js
@@ -76,3 +76,13 @@ export async function embed(text) {
     embeddingsDict[text] = e0["data"];
     return e0["data"];
 }
+
+
+export async function computeQueryEmbedding(inputQuery){
+    let queryEmbedding = await embed(inputQuery);
+    return queryEmbedding["data"]
+}
+
+export async function getTokens(text) {
+    return await tokenizer(text)["input_ids"]["data"];
+}

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,30 +1,108 @@
-
-/**
- * @param {string} str 
- * @param {number} length 
- * @returns {Array<string>}
- */
-export function splitSubstrings(str, length) {
-    const words = str.split(' ');
-    const chunks = [];
-
-    for (let i = 0; i < words.length; i++) {
-        const word = words[i];
-
-        if (chunks.length === 0 || chunks[chunks.length - 1].length + word.length + 1 > length) {
-            chunks.push(word);
-        } else {
-            chunks[chunks.length - 1] += ' ' + word;
-        }
-    }
-    return chunks;
-}
+import {getTokens} from "./semantic";
 
 /**
  * 
  * @param {string} paragraph 
  * @returns {Array<string> | null}
  */
-export function splitIntoSentences(paragraph) {
+function splitIntoSentences(paragraph) {
     return paragraph.match(/[^\.!\?]+[\.!\?]+/g);
+}
+
+
+export async function splitText(text) {
+    const splitType = document.getElementById('split-type').value;
+    const splitParam = document.getElementById('split-param').value;
+
+    switch(splitType) {
+        case 'Regex':
+            return splitByRegex(text, splitParam);
+        case 'Sentence':
+            return splitBySentences(text);
+        case 'Words':
+            return splitByWords(text, parseInt(splitParam));
+        case 'Chars':
+            return splitByChars(text, parseInt(splitParam));
+        case 'Tokens':
+            return await splitByTokens(text, parseInt(splitParam));
+        default:
+            console.error('Invalid split type');
+            return null;
+    }
+}
+
+async function splitByTokens(str, numTokens) {
+    const words = str.split(' ');
+    const chunks = [];
+
+    for (let i = 0; i < words.length; i++) {
+        const word = words[i];
+        const tokens = await getTokens(word);
+
+        // Check if there's no chunk or if the last chunk + the new word would exceed numTokens
+        if (chunks.length === 0 || (await getTokens(chunks[chunks.length - 1])).length + tokens.length > numTokens) {
+            chunks.push(word);
+        } else {
+            chunks[chunks.length - 1] += ' ' + word;
+        }
+    }
+    console.table(chunks);
+    return chunks;
+}
+
+
+function splitByWords(str, numWords) {
+    if (isNaN(numWords) || !Number.isInteger(numWords)) {
+        console.error("numWords must be an integer.");
+        return null;
+    }
+
+    const words = str.split(" ");
+    const chunks = [];
+
+    let currentChunk = [];
+    for (let i = 0; i < words.length; i++) {
+        currentChunk.push(words[i]);
+
+        if (currentChunk.length === numWords) {
+            chunks.push(currentChunk.join(' '));
+            currentChunk = [];
+        }
+    }
+
+    if (currentChunk.length > 0) {
+        chunks.push(currentChunk.join(' '));
+    }
+
+    console.table(chunks);
+    return chunks;
+}
+
+
+function splitByChars(str, numChars) {
+    const words = str.split(' ');
+    const chunks = [];
+
+    for (let i = 0; i < words.length; i++) {
+        const word = words[i];
+
+        if (chunks.length === 0 || chunks[chunks.length - 1].length + word.length + 1 > numChars) {
+            chunks.push(word);
+        } else {
+            chunks[chunks.length - 1] += ' ' + word;
+        }
+    }
+    console.table(chunks);
+
+    return chunks;
+}
+
+
+function splitBySentences(text) {
+    return text.match(/[^\.!\?]+[\.!\?]+/g);
+}
+
+function splitByRegex(str, r) {
+    let regex = new RegExp(r, 'g');
+    return str.split(regex);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "css-loader": "^6.8.1",
         "html-webpack-plugin": "^5.5.3",
+        "mini-css-extract-plugin": "^2.7.6",
         "style-loader": "^3.3.3",
         "webpack": "^5.88.1",
         "webpack-cli": "^5.1.4",
@@ -2605,6 +2606,78 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mini-css-extract-plugin": {
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.6.tgz",
+      "integrity": "sha512-Qk7HcgaPkGG6eD77mLvZS1nmxlao3j+9PkrT9Uc7HAE1id3F41+DdBRYRYkbyfNRGzm8/YWtzhw7nVPmwhqTQw==",
+      "dev": true,
+      "dependencies": {
+        "schema-utils": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
+      "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/minimalistic-assert": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "css-loader": "^6.8.1",
     "html-webpack-plugin": "^5.5.3",
+    "mini-css-extract-plugin": "^2.7.6",
     "style-loader": "^3.3.3",
     "webpack": "^5.88.1",
     "webpack-cli": "^5.1.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin'); // FOUC-correction
 
 module.exports = {
   entry: './js/index.js',
@@ -12,7 +13,8 @@ module.exports = {
     rules: [
       {
         test: /\.css$/,
-        use: ['style-loader', 'css-loader'],
+        use: [MiniCssExtractPlugin.loader, 'css-loader'],
+
       },
     ],
   },
@@ -20,5 +22,6 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: './index.html',
     }),
+    new MiniCssExtractPlugin(),
   ],
 };


### PR DESCRIPTION
I added an advanced settings dropdown and moved the submit button up as mentioned in [previous issues.](https://github.com/do-me/SemanticFinder/issues/10) While I retained @lizozom's type-checking and jsdoc changes, my added code does not yet have types. 

I implemented some minor changes to correct the pesky [FOUC](https://en.wikipedia.org/wiki/Flash_of_unstyled_content#:~:text=A%20flash%20of%20unstyled%20content,before%20all%20information%20is%20retrieved.) we have been getting, including using MiniCssExtractPlugin to extract the CSS into separate files.

As always, PR live at the site: https://varunnsrivastava.github.io/SemanticFinder/

I'm finding my current implementation of the advanced settings dropdown to be a bit ugly. Any one should feel free to correct it using CSS/bootstrap magic. 