### PR TITLE
Removed 'tabs' permission

### DIFF
--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -5,7 +5,6 @@
   "version": "0.0.1",
   "host_permissions": ["http://*/*", "https://*/*"],
   "permissions": [
-    "tabs",
     "activeTab",
     "storage",
     "unlimitedStorage"

--- a/extension/src/content/content.js
+++ b/extension/src/content/content.js
@@ -54,7 +54,7 @@ chrome.runtime.onMessage.addListener(async function(request, sender) {
             const numChars = await fetchNumChars();
             let texts = [];
             // hacky support for pdf
-            if (currentURL.endsWith('.pdf')) {
+            if (currentURL.includes('pdf')) {
                 let textContent = await fetchAndExtractPDFText(currentURL);
                 texts = splitReadableContent(textContent, numChars);
 


### PR DESCRIPTION
Apparently it is not needed, and was cause for recent rejection by the chrome store. This process is tedious but hopefully we won't need to go through it again. 